### PR TITLE
lib: use void for infallible error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@
 //! code. The above example is a cut-down version of the `ssd1322` example.
 
 #![no_std]
-#![feature(never_type)]
 #![feature(optin_builtin_traits)]
 
 pub extern crate lpc81x_pac as lpc81x;

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -68,29 +68,29 @@ macro_rules! pin {
         unsafe impl super::InputPin for $name<mode::Unassigned> {}
 
         impl embedded_hal::digital::v2::InputPin for $name<mode::DigitalInput> {
-            type Error = !;
+            type Error = void::Void;
 
-            fn is_high(&self) -> Result<bool, !> {
+            fn is_high(&self) -> Result<bool, void::Void> {
                 let gpio = lpc81x_pac::GPIO_PORT::ptr();
                 Ok(unsafe { (*gpio).b[Self::NUMBER as usize].read().bits() != 0 })
             }
 
-            fn is_low(&self) -> Result<bool, !> {
+            fn is_low(&self) -> Result<bool, void::Void> {
                 let gpio = lpc81x_pac::GPIO_PORT::ptr();
                 Ok(unsafe { (*gpio).b[Self::NUMBER as usize].read().bits() == 0 })
             }
         }
 
         impl embedded_hal::digital::v2::OutputPin for $name<mode::DigitalOutput> {
-            type Error = !;
+            type Error = void::Void;
 
-            fn set_high(&mut self) -> Result<(), !> {
+            fn set_high(&mut self) -> Result<(), void::Void> {
                 let gpio = lpc81x_pac::GPIO_PORT::ptr();
                 unsafe { (*gpio).set0.write(|w| w.bits(Self::REG_MASK)) };
                 Ok(())
             }
 
-            fn set_low(&mut self) -> Result<(), !> {
+            fn set_low(&mut self) -> Result<(), void::Void> {
                 let gpio = lpc81x_pac::GPIO_PORT::ptr();
                 unsafe { (*gpio).clr0.write(|w| w.bits(Self::REG_MASK)) };
                 Ok(())
@@ -98,9 +98,9 @@ macro_rules! pin {
         }
 
         impl embedded_hal::digital::v2::ToggleableOutputPin for $name<mode::DigitalOutput> {
-            type Error = !;
+            type Error = void::Void;
 
-            fn toggle(&mut self) -> Result<(), !> {
+            fn toggle(&mut self) -> Result<(), void::Void> {
                 let gpio = lpc81x_pac::GPIO_PORT::ptr();
                 unsafe { (*gpio).not0.write(|w| w.bits(Self::REG_MASK)) };
                 Ok(())

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -239,7 +239,7 @@ macro_rules! spi_device {
             MISO: pins::PinAssignment,
             SSEL: pins::PinAssignment,
         {
-            type Error = !;
+            type Error = void::Void;
 
             /// Sends a word (from 1 to 16 bits) over the SPI interface.
             ///
@@ -249,7 +249,7 @@ macro_rules! spi_device {
             /// When using this trait implementation, implement chip select as
             /// a generic digital output pin instead, because that is what
             /// embedded-hal device drivers expect.
-            fn send(&mut self, word: W) -> Result<(), nb::Error<!>> {
+            fn send(&mut self, word: W) -> Result<(), nb::Error<void::Void>> {
                 let periph = lpc81x_pac::$typename::ptr();
                 let stat = unsafe { (*periph).stat.read() };
                 if stat.txrdy().bit_is_clear() {
@@ -270,7 +270,7 @@ macro_rules! spi_device {
             ///
             /// Calling `read` once for every `send` is mandatory in order to
             /// leave the SPI bus in a correct state for subsequent transfers.
-            fn read(&mut self) -> Result<W, nb::Error<!>> {
+            fn read(&mut self) -> Result<W, nb::Error<void::Void>> {
                 let periph = lpc81x_pac::$typename::ptr();
                 let stat = unsafe { (*periph).stat.read() };
                 if stat.rxrdy().bit_is_clear() {


### PR DESCRIPTION
This replaces some usage of the (unstable) never type with the `void` crate, which is anyway already part of the dependency tree. It brings the library one step closer to build with a stable toolchain.